### PR TITLE
Implement `getMermaidBlock` method to extract mermaid diagram block from LLM responses

### DIFF
--- a/src/view/output-formatter.ts
+++ b/src/view/output-formatter.ts
@@ -3,7 +3,8 @@ import { MermaidLinkGenerator } from "./mermaid/link-generator";
 
 export class OutputFormatter {
     public static getDiagramFileContent(modelName: string, llmResponse: string): string {
-        const mermaidCode = (llmResponse.match(/```mermaid([\s\S]*?)```/) || ["", ""])[1].trim();
+        const mermaidBlock = this.getMermaidBlock(llmResponse);
+        const mermaidCode = mermaidBlock.replace(/```mermaid|```/g, "");
         const linkGenerator = new MermaidLinkGenerator(mermaidCode);
 
         return `<p align="center">
@@ -21,7 +22,17 @@ For any issues or feature requests, please visit our [GitHub repository](https:/
 **Model**: ${modelName}  
 **Mermaid Live Editor**: [View](${linkGenerator.createViewLink()}) | [Edit](${linkGenerator.createEditLink()})
 
-${llmResponse}`;
+${mermaidBlock}`;
+    }
+
+    public static getMermaidBlock(llmResponse: string): string {
+        const matches = llmResponse.match(/```mermaid[\s\S]*```/);
+
+        if (!matches) {
+            throw new Error("No Mermaid block found in the language model response. Please try again.");
+        }
+
+        return matches[0];
     }
 
     public static getLogFileContent(

--- a/src/view/output-formatter.ts
+++ b/src/view/output-formatter.ts
@@ -3,7 +3,7 @@ import { MermaidLinkGenerator } from "./mermaid/link-generator";
 
 export class OutputFormatter {
     public static getDiagramFileContent(modelName: string, llmResponse: string): string {
-        const mermaidCode = llmResponse.replace(/```mermaid|```/g, "");
+        const mermaidCode = (llmResponse.match(/```mermaid([\s\S]*?)```/) || ["", ""])[1].trim();
         const linkGenerator = new MermaidLinkGenerator(mermaidCode);
 
         return `<p align="center">


### PR DESCRIPTION
Closes #8 

### Changes made:

- Added the `getMermaidBlock` method to the `OutputFormatter` class to extract the mermaid diagram block from the `llmResponse` using regex (contributed by @ozanani).
- Updated the `OutputFormatter` class to pass the extracted `mermaidBlock` to the output instead of the `llmResponse` (contributed by @ozanani).