### PR TITLE
Fix cycles in mermaid code with `removeMermaidCodeCycles()` method

### DIFF
--- a/src/view/tests/output-formatter.test.ts
+++ b/src/view/tests/output-formatter.test.ts
@@ -38,6 +38,16 @@ suite("OutputFormatter Test Suite", () => {
         runInvalidResponseTest(emptyRepsonse);
     });
 
+    test("on a cyclic mermaid code, removeMermaidCodeCycles resolves the cycle", () => {
+        const cyclicMermaidCode = 
+            "graph TD\n    subgraph Extension\n        Extension[Extension Entry Point]\n        CreateArchitectureCommand[Create Architecture Command]\n    end\n\n    Extension --> CreateArchitectureCommand\n";
+        const resolvedMermaidCode = OutputFormatter.removeMermaidCodeCycles(cyclicMermaidCode);
+        const expectedResolvedMermaidCode = 
+            "graph TD\n    subgraph Extension\_\n        Extension[Extension Entry Point]\n        CreateArchitectureCommand[Create Architecture Command]\n    end\n\n    Extension --> CreateArchitectureCommand\n";
+        
+        assert.equal(resolvedMermaidCode, expectedResolvedMermaidCode);
+    });
+
     function runValidResponseTest(llmResponse: string, expectedResult: string): void {
         const result = OutputFormatter.getMermaidBlock(llmResponse);
         assert.equal(result, expectedResult);


### PR DESCRIPTION
Closes #7

### Changes made:

- Created the `removeMermaidCodeCycles()` method in the `OutputFormatter` class to resolve cycles in mermaid code by renaming subgraphs with conflicting node names.
- Added a simple test case to ensure the method properly handles cyclic mermaid code and resolves the cycle correctly.


All tests pass successfully as shown below:
![image](https://github.com/user-attachments/assets/943bab89-f947-4215-aacd-3204220d2504)