### PR TITLE
Create initial CI GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.12.1'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.12.1'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
Closes #13 

This PR sets up the initial CI workflow using GitHub Actions. It triggers on `push` and `pull_request` events to the `main` branch. The workflow runs on a Windows environment, checks out the code, sets up Node.js (version 20.12.1 to avoid [this error](https://github.com/microsoft/vscode-vsce/issues/969)), installs dependencies and runs the tests.



