### PR TITLE
Add Lua and Dart to default list of supported languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
                         "scala",
                         "swift",
                         "kt",
-                        "kts"
+                        "kts",
+                        "lua",
+                        "dart"
                     ],
                     "description": "List of file extensions to include in search."
                 },


### PR DESCRIPTION
Closes #25 

#### Changes made

- Added `lua` and `dart` to **swark.fileExtensions["default"]** property of `package.json` file.

![image](https://github.com/user-attachments/assets/d9a7ca0d-70aa-4f82-85a1-c03ccf379aec)
